### PR TITLE
fixing a data race

### DIFF
--- a/omp_smithW.c
+++ b/omp_smithW.c
@@ -276,8 +276,8 @@ void similarityScore(long long int i, long long int j, int* H, int* P, long long
     P[index] = pred;
 
     //Updates maximum score to be used as seed on backtrack
-    if (max > H[*maxPos]) {
-        #pragma omp critical
+    #pragma omp critical
+    if (max > H[*maxPos]) {        
         *maxPos = index;
     }
 


### PR DESCRIPTION
Both read and write access to *maxPos should be protected.